### PR TITLE
Significantly improve example by using a similar graph component implementation

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -2,7 +2,13 @@
 
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-var app = new EmberApp();
+var app = new EmberApp({
+  vendorFiles: {
+    'ember.js': {
+      development: 'bower_components/ember/ember.prod.js'
+    }
+  }
+});
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/app/components/x-graph-content.js
+++ b/app/components/x-graph-content.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import Graph from './x-graph';
+
+export default Ember.Component.extend({
+  tagName: '',
+  transform: Ember.computed(function() {
+    let graph = this.attrs.graph.value;
+    return `translate(${graph.graphX()}, ${graph.graphY()})`;
+  })
+});

--- a/app/components/x-graph.js
+++ b/app/components/x-graph.js
@@ -1,0 +1,52 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  graphX() {
+    return this.attrs.marginLeft;
+  },
+
+  graphY() {
+    return this.attrs.marginTop;
+  },
+
+  graphHeight: Ember.computed(function() {
+    return this.attrs.height - this.attrs.marginBottom - this.attrs.marginTop;
+  }),
+
+  graphWidth: Ember.computed(function() {
+    return this.attrs.width - this.attrs.marginLeft - this.attrs.marginRight;
+  }),
+
+  getWidth() {
+    return this.attrs.width || 200;
+  },
+
+  getHeight() {
+    return this.attrs.height || 100;
+  },
+
+  scaleX() {
+    return d3.scale.linear().domain(this.domainX()).range(this.rangeX());
+  },
+
+  scaleY() {
+    return d3.scale.linear().domain(this.domainY()).range(this.rangeY());
+  },
+
+  domainX() {
+    return [this.attrs.leftX, this.attrs.rightX];
+  },
+
+  domainY() {
+    return [this.attrs.bottomY, this.attrs.topY];
+  },
+
+  rangeX() {
+    return [0, this.get('graphWidth')];
+  },
+
+  rangeY() {
+    return [this.get('graphHeight'), 0];
+  }
+
+});

--- a/app/components/x-line.js
+++ b/app/components/x-line.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: '',
+
+  path: Ember.computed(function() {
+    let graph = this.attrs.graph.value;
+
+    var scaleX = graph.scaleX();
+    var scaleY = graph.scaleY();
+    var lineFn = d3.svg.line()
+      .x(d => scaleX(d.x))
+      .y(d => scaleY(d.y));
+
+    return lineFn(this.attrs.data.value);
+  })
+});

--- a/app/components/x-x-axis.js
+++ b/app/components/x-x-axis.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: "",
+
+  ticks: Ember.computed(function() {
+    let graph = this.attrs.graph.value;
+
+    var xOffset = graph.graphX();
+    var scaleX = graph.scaleX();
+    var y = graph.getHeight() - this.attrs.height + 5;
+    return scaleX.ticks(this.attrs.count || 8)
+      .map(tick => {
+        return {
+          x: xOffset + scaleX(tick),
+          value: tick,
+          y: y
+        };
+      });
+  })
+});

--- a/app/components/x-y-axis.js
+++ b/app/components/x-y-axis.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: '',
+
+  ticks: Ember.computed(function() {
+    let graph = this.attrs.graph.value;
+
+    var yOffset = graph.graphY();
+    var scaleY = graph.scaleY();
+    var x = this.attrs.width - 5;
+    return scaleY.ticks(this.attrs.count || 5)
+      .map(tick => ({
+        y: scaleY(tick) + yOffset,
+        value: tick,
+        x: x
+      }));
+  })
+});

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    toggle() {
+      this.toggleProperty('isShowing');
+    }
+  }
+});

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model: function(){
-    return range(100).map(() => range(30).map(x => ({ x, y: Math.random() * 100 })));
+    return d3.range(0, 100).map((id) => ({ id, data: d3.range(100).map(x => ({ x, y: Math.random() * 100 })) }));
   }
 });
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,13 +1,27 @@
-.baseline path {
-	fill: none;
-	stroke: red;
-	stroke-width: 1px;
+.x-line-path {
+  fill: none;
+  stroke-width: 1px;
+  stroke: red;
 }
-.baseline text {
-	font-family: "san-serif";
-	font-size: 10px;
+
+.x-x-axis-tick > text {
+  font-family: Consolas, Monospaced;
+  font-size: 12px;
+  alignment-baseline: hanging;
+  text-anchor: middle;
 }
-.baseline line {
-	stroke: lightgray;
-	stroke-width: 1px;	
+
+.x-graph-bg {
+  fill: #eeeeee;
+}
+
+.x-graph-content-bg {
+  fill: white;
+}
+
+.x-y-axis-tick > text {
+  font-family: Consolas, Monospaced;
+  font-size: 12px;
+  text-anchor: end;
+  alignment-baseline: middle;
 }

--- a/app/templates/components/x-graph-content.hbs
+++ b/app/templates/components/x-graph-content.hbs
@@ -1,0 +1,4 @@
+<g transform={{transform}}>
+  <rect class="x-graph-content-bg" x="0" y="0" width={{graph.graphWidth}} height={{graph.graphHeight}} />
+  {{yield}}
+</g>

--- a/app/templates/components/x-graph.hbs
+++ b/app/templates/components/x-graph.hbs
@@ -1,0 +1,4 @@
+<svg class="x-graph" width={{width}} height={{height}}>
+  <rect class="x-graph-bg" x="0" y="0" width={{width}} height={{height}} />
+  {{yield this}}
+</svg>

--- a/app/templates/components/x-line.hbs
+++ b/app/templates/components/x-line.hbs
@@ -1,0 +1,3 @@
+<g class="x-line">
+  <path class="x-line-path" d={{path}} />
+</g>

--- a/app/templates/components/x-x-axis.hbs
+++ b/app/templates/components/x-x-axis.hbs
@@ -1,0 +1,8 @@
+<g class="x-x-axis">
+  {{#each ticks as |tick|}}
+    <g class="x-x-axis-tick"
+       transform="translate({{tick.x}}, {{tick.y}})">
+      {{yield tick.value}}
+    </g>
+  {{/each}}
+</g>

--- a/app/templates/components/x-y-axis.hbs
+++ b/app/templates/components/x-y-axis.hbs
@@ -1,0 +1,7 @@
+<g class="x-y-axis">
+  {{#each ticks as |tick|}}
+    <g class="x-y-axis-tick" transform="translate({{tick.x}}, {{tick.y}})">
+      {{yield tick.value}}
+    </g>
+  {{/each}}
+</g>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,11 +1,33 @@
 <h1>Is Ember Really Fast Yet?</h1>
 <h3>Test #1: graphs in an each</h3>
-{{#each graphData in model}}
-  {{#nf-graph width=200 height=75}}
-    {{#nf-graph-content}}
-      {{nf-line data=graphData}}
-    {{/nf-graph-content}}
-    {{#nf-x-axis as |tick|}}<text>{{tick.value}}</text>{{/nf-x-axis}}
-    {{#nf-y-axis as |tick|}}<text>{{tick.value}}</text>{{/nf-y-axis}}
-  {{/nf-graph}}
-{{/each}}
+
+<button {{action "toggle"}}>Show/hide</button>
+
+{{#if isShowing}}
+  {{#each model as |line|}}
+    {{#x-graph
+      minX=0
+      maxX=100
+      topY=100
+      rightX=100
+      bottomY=0
+      leftX=0
+      width=200
+      height=100
+      marginBottom=20
+      marginLeft=50
+      marginRight=10
+      marginTop=10 as |graph|}}
+        {{#x-graph-content graph=graph}}
+          {{x-line data=line.data graph=graph}}
+        {{/x-graph-content}}
+      {{#x-x-axis graph=graph height=20 count=8 as |tick|}}
+        <text>{{tick}}</text>
+      {{/x-x-axis}}
+
+      {{#x-y-axis graph=graph width=50 count=5 as |tick|}}
+        <text>{{tick}}</text>
+      {{/x-y-axis}}
+    {{/x-graph}}
+  {{/each}}
+{{/if}}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "is-ember-really-fast-yet",
   "dependencies": {
-    "ember": "1.12.0-beta.1+canary.27ed45f8",
+    "ember": "canary",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.0.0-beta.16.1",
@@ -15,5 +15,8 @@
     "d3": "~3.5.3",
     "rx-ember": "0.2.5-1",
     "rxjs": "~2.5.2"
+  },
+  "resolutions": {
+    "ember": "canary"
   }
 }

--- a/tests/unit/components/x-graph-content-test.js
+++ b/tests/unit/components/x-graph-content-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('x-graph-content', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/x-graph-test.js
+++ b/tests/unit/components/x-graph-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('x-graph', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/x-line-test.js
+++ b/tests/unit/components/x-line-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('x-line', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/x-x-axis-test.js
+++ b/tests/unit/components/x-x-axis-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('x-x-axis', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/tests/unit/components/x-y-axis-test.js
+++ b/tests/unit/components/x-y-axis-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('x-y-axis', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});


### PR DESCRIPTION
It's never a good idea to publicly compare the performance of things when the underlying code you're testing is significantly different in feature set.

I've updated your Ember example to match the React example by pretty much copy/pasting over templates and code.

I've also made it run on Ember canary.
